### PR TITLE
Added Wait in Handoff

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -111,7 +111,7 @@ public final class Constants {
         public static final double SAFETY_ANGLE_UPWARD_DEGREES = -40;
 
         // Arm Setpoints
-        public static final double ZERO_ANGLE_DEGREES = -85;
+        public static final double ZERO_ANGLE_DEGREES = -90;
         public static final double PROCESSOR_ANGLE_DEGREES = -45;
 
         public static final double L1_ANGLE_DEGREES = 25;

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -118,6 +118,7 @@ public class RobotContainer {
                                         ),
                                 FunnelCommands.IntakeCoral(m_funnelIndexerSubsystem)
                         ),
+                        new WaitCommand(0.5),
                         // Intake coral until funnel no longer detects it (shallow beam break)
                         new ParallelCommandGroup(
                                 EndEffectorCommands.IntakeEffector(IntakeMode.CORAL),


### PR DESCRIPTION
Added wait after elevator+arm moves to zero, before outtaking funnel, to prevent coral from being ejected too early