### PR TITLE
Direct Coral Handoff

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -165,6 +165,8 @@ public class RobotContainer {
                     0));
     Command driveFieldOrientedDirectAngleSim = m_swerveSubsystem.driveFieldOriented(driveDirectAngleSim);
 
+    private Command
+
     private Command coralHandoffCommand() {
         return new ConditionalCommand(
                 new SequentialCommandGroup(
@@ -173,11 +175,11 @@ public class RobotContainer {
                                 new MoveElevatorArmCommand(ElevatorPosition.ZERO)
                                         .until(
                                                 () -> m_elevatorSubsystem.getElevatorPositionEnum() == ElevatorPosition.ZERO
+                                                        && m_armSubsystem.getArmPositionEnum() == ElevatorPosition.ZERO
                                                         && m_funnelIndexerSubsystem.getHasCoral()
                                         ),
                                 FunnelCommands.IntakeCoral(m_funnelIndexerSubsystem)
                         ),
-                        new WaitCommand(0.25),
                         // Intake coral until funnel no longer detects it (shallow beam break)
                         new ParallelCommandGroup(
                                 EndEffectorCommands.IntakeEffector(IntakeMode.CORAL),

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -47,7 +47,7 @@ import frc.robot.subsystems.ElevatorSubsystem.ElevatorPosition;
  */
 public class RobotContainer {
     // The robot's subsystems and commands are defined here...
-    private final FunnelSubsystem m_funnelIndexerSubsystem = new FunnelSubsystem();
+    public final static FunnelSubsystem m_funnelIndexerSubsystem = new FunnelSubsystem();
     public final static EndEffectorSubsystem m_endEffectorSubsystem = new EndEffectorSubsystem();
     public final static ElevatorSubsystem m_elevatorSubsystem = new ElevatorSubsystem();
     public final static ArmSubsystem m_armSubsystem = new ArmSubsystem();
@@ -113,7 +113,7 @@ public class RobotContainer {
                         new MoveElevatorArmCommand(ElevatorPosition.ALGAE_LOW),
                         new IntakeCommand(IntakeMode.ALGAE)));
 
-        new EventTrigger("outtakecoral").onTrue(new OuttakeCoralCommand(m_funnelIndexerSubsystem));
+        new EventTrigger("outtakecoral").onTrue(new OuttakeCoralCommand());
         new EventTrigger("outtakealgae").onTrue(new OuttakeCommand());
 
         SmartDashboard.putData("Auto Chooser", autoChooser);
@@ -165,8 +165,6 @@ public class RobotContainer {
                     0));
     Command driveFieldOrientedDirectAngleSim = m_swerveSubsystem.driveFieldOriented(driveDirectAngleSim);
 
-    private Command
-
     private Command coralHandoffCommand() {
         return new ConditionalCommand(
                 new SequentialCommandGroup(
@@ -176,21 +174,27 @@ public class RobotContainer {
                                         .until(
                                                 () -> m_elevatorSubsystem.getElevatorPositionEnum() == ElevatorPosition.ZERO
                                                         && m_armSubsystem.getArmPositionEnum() == ElevatorPosition.ZERO
-                                                        && m_funnelIndexerSubsystem.getHasCoral()
                                         ),
-                                FunnelCommands.IntakeCoral(m_funnelIndexerSubsystem)
+                                FunnelCommands.IntakeCoral()
+                        ),
+                        // If no coral in funnel yet, run pass through cmd to shoot coral directly into end effector
+                        // If coral already in funnel, skip this step
+                        new ConditionalCommand(
+                                new InstantCommand(),
+                                FunnelCommands.PassThroughCoral(),
+                                m_funnelIndexerSubsystem::getHasCoral
                         ),
                         // Intake coral until funnel no longer detects it (shallow beam break)
                         new ParallelCommandGroup(
                                 EndEffectorCommands.IntakeEffector(IntakeMode.CORAL),
-                                FunnelCommands.OuttakeCoral(m_funnelIndexerSubsystem)
+                                FunnelCommands.OuttakeCoral()
                         ).until(
                                 () -> !m_funnelIndexerSubsystem.getHasCoral()
                         ),
                         // Run end effector intake, funnel intake, and move elevator + arm to level 1 simultaneously
                         new ParallelCommandGroup(
                                 EndEffectorCommands.IntakeEffector(IntakeMode.CORAL),
-                                FunnelCommands.OuttakeCoral(m_funnelIndexerSubsystem),
+                                FunnelCommands.OuttakeCoral(),
                                 new MoveElevatorArmCommand(ElevatorPosition.REST)
                         )
                 ),
@@ -250,7 +254,7 @@ public class RobotContainer {
         m_funnelIndexerSubsystem.setDefaultCommand(
                 new ConditionalCommand(
                         new InstantCommand(),
-                        FunnelCommands.IntakeCoral(m_funnelIndexerSubsystem),
+                        FunnelCommands.IntakeCoral(),
                         m_endEffectorSubsystem::hasCoral
                 )
         );

--- a/src/main/java/frc/robot/commands/FunnelCommands.java
+++ b/src/main/java/frc/robot/commands/FunnelCommands.java
@@ -2,14 +2,18 @@ package frc.robot.commands;
 
 import frc.robot.commands.funnel_indexer.IntakeCoralCommand;
 import frc.robot.commands.funnel_indexer.OuttakeCoralCommand;
-import frc.robot.subsystems.FunnelSubsystem;
+import frc.robot.commands.funnel_indexer.PassThroughCoralCommand;
 
 public class FunnelCommands {
-    public static OuttakeCoralCommand OuttakeCoral(FunnelSubsystem funnelIndexerSubsystem) {
-        return new OuttakeCoralCommand(funnelIndexerSubsystem);
+    public static OuttakeCoralCommand OuttakeCoral() {
+        return new OuttakeCoralCommand();
     }
 
-    public static IntakeCoralCommand IntakeCoral(FunnelSubsystem funnelIndexerSubsystem) {
-        return new IntakeCoralCommand(funnelIndexerSubsystem);
+    public static IntakeCoralCommand IntakeCoral() {
+        return new IntakeCoralCommand();
+    }
+
+    public static PassThroughCoralCommand PassThroughCoral() {
+        return new PassThroughCoralCommand();
     }
 }

--- a/src/main/java/frc/robot/commands/funnel_indexer/IntakeCoralCommand.java
+++ b/src/main/java/frc/robot/commands/funnel_indexer/IntakeCoralCommand.java
@@ -2,12 +2,11 @@ package frc.robot.commands.funnel_indexer;
 
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.Constants.FunnelIndexerConstants;
-import frc.robot.subsystems.FunnelSubsystem;
+import frc.robot.RobotContainer;
 
 import java.util.Map;
 
 public class IntakeCoralCommand extends Command {
-    private final FunnelSubsystem m_funnelIndexerSubsystem;
 
     // Enum representing the state of the beam breaks
     enum BeamBreakState {
@@ -36,9 +35,8 @@ public class IntakeCoralCommand extends Command {
     /**
      * Creates a new CorrectCoralPositionCommand.
      */
-    public IntakeCoralCommand(FunnelSubsystem funnelIndexerSubsystem) {
-        this.m_funnelIndexerSubsystem = funnelIndexerSubsystem;
-        addRequirements(funnelIndexerSubsystem);
+    public IntakeCoralCommand() {
+        addRequirements(RobotContainer.m_funnelIndexerSubsystem);
     }
 
     // Called when the command is initially scheduled.
@@ -52,8 +50,8 @@ public class IntakeCoralCommand extends Command {
      * @return An enum representing which beam breaks are broken.
      */
     private BeamBreakState getBeamBreakState() {
-        boolean shallow = m_funnelIndexerSubsystem.isShallowBeamBreakBroken();
-        boolean deep = m_funnelIndexerSubsystem.isDeepBeamBreakBroken();
+        boolean shallow = RobotContainer.m_funnelIndexerSubsystem.isShallowBeamBreakBroken();
+        boolean deep = RobotContainer.m_funnelIndexerSubsystem.isDeepBeamBreakBroken();
         if (!shallow && !deep) return BeamBreakState.NONE_BROKEN;
         if (shallow && deep) return BeamBreakState.BOTH_BROKEN;
 
@@ -70,20 +68,20 @@ public class IntakeCoralCommand extends Command {
 
         // Get the speed based on whether we have coral or not
         double speed;
-        if (m_funnelIndexerSubsystem.getHasCoral()) {
+        if (RobotContainer.m_funnelIndexerSubsystem.getHasCoral()) {
             speed = HAS_CORAL_SPEED_MAP.get(state);
         } else {
             speed = SPEED_MAP.get(state);
         }
 
         // Set the indexer speed
-        m_funnelIndexerSubsystem.setIndexerSpeed(speed);
+        RobotContainer.m_funnelIndexerSubsystem.setIndexerSpeed(speed);
     }
 
     // Called once the command ends or is interrupted.
     @Override
     public void end(boolean interrupted) {
-        m_funnelIndexerSubsystem.stop();
+        RobotContainer.m_funnelIndexerSubsystem.stop();
     }
 
     // Returns true when the command should end.

--- a/src/main/java/frc/robot/commands/funnel_indexer/OuttakeCoralCommand.java
+++ b/src/main/java/frc/robot/commands/funnel_indexer/OuttakeCoralCommand.java
@@ -2,23 +2,22 @@ package frc.robot.commands.funnel_indexer;
 
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.Constants.FunnelIndexerConstants;
+import frc.robot.RobotContainer;
 import frc.robot.subsystems.FunnelSubsystem;
 
 public class OuttakeCoralCommand extends Command {
-    private final FunnelSubsystem m_funnelIndexerSubsystem;
 
-    public OuttakeCoralCommand(FunnelSubsystem funnelIndexerSubsystem) {
-        this.m_funnelIndexerSubsystem = funnelIndexerSubsystem;
-        addRequirements(funnelIndexerSubsystem);
+    public OuttakeCoralCommand() {
+        addRequirements(RobotContainer.m_funnelIndexerSubsystem);
     }
 
     @Override
     public void execute() {
-        m_funnelIndexerSubsystem.setIndexerSpeed(FunnelIndexerConstants.OUTTAKE_SPEED);
+        RobotContainer.m_funnelIndexerSubsystem.setIndexerSpeed(FunnelIndexerConstants.OUTTAKE_SPEED);
     }
 
     @Override
     public boolean isFinished() {
-        return !m_funnelIndexerSubsystem.isShallowBeamBreakBroken() && !m_funnelIndexerSubsystem.isDeepBeamBreakBroken();
+        return !RobotContainer.m_funnelIndexerSubsystem.isShallowBeamBreakBroken() && !RobotContainer.m_funnelIndexerSubsystem.isDeepBeamBreakBroken();
     }
 }

--- a/src/main/java/frc/robot/commands/funnel_indexer/PassThroughCoralCommand.java
+++ b/src/main/java/frc/robot/commands/funnel_indexer/PassThroughCoralCommand.java
@@ -1,0 +1,27 @@
+package frc.robot.commands.funnel_indexer;
+
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.Constants;
+import frc.robot.RobotContainer;
+
+public class PassThroughCoralCommand extends Command {
+
+    public PassThroughCoralCommand() {
+        addRequirements(RobotContainer.m_funnelIndexerSubsystem);
+    }
+
+    @Override
+    public void initialize() {
+        RobotContainer.m_funnelIndexerSubsystem.setIndexerSpeed(Constants.FunnelIndexerConstants.FULL_SPEED);
+    }
+
+    @Override
+    public boolean isFinished() {
+        return !RobotContainer.m_funnelIndexerSubsystem.isShallowBeamBreakBroken() && RobotContainer.m_funnelIndexerSubsystem.isDeepBeamBreakBroken();
+    }
+
+    @Override
+    public void end(boolean interrupted) {
+        RobotContainer.m_funnelIndexerSubsystem.stop();
+    }
+}


### PR DESCRIPTION
If the elev & arm is already in position to accept coral, but no coral is in the funnel yet,
if the driver is continuing to hold the 'intake' button, then pass the coral directly through the funnel to the end effector at full speed, instead of waiting for the funnel to 'have the coral' before doing the handoff